### PR TITLE
Add Unidata to Examples of FOSS table, Annex B

### DIFF
--- a/guide/sections/annex-examples.adoc
+++ b/guide/sections/annex-examples.adoc
@@ -11,4 +11,8 @@
 |GitHub
 |https://github.com/ECCC-MSC
 
+|NSF Unidata
+|GitHub
+|https://github.com/Unidata
+
 |===


### PR DESCRIPTION
This PR adds Unidata do the table in Annex B referencing the Unidata GitHub space.

It has me wondering if it would be useful for each organization to highlight a few particular OSS projects of interest to the WMO community. The Unidata GitHub space, for instance, contains over a hundred repos only a few of which are likely of broad interest. So just referencing an organizations GitHub space might not be as useful as mentioning a few specific projects.