### PR TITLE
add sections on RIs and skills

### DIFF
--- a/guide/sections/guidelines/wmo-activities.adoc
+++ b/guide/sections/guidelines/wmo-activities.adoc
@@ -2,169 +2,89 @@
 
 ==== Coordination, alignment and support
 
-As FOSS has become increasingly embedded in WMO programmes, projects and Member operations, the need for structured
-coordination at the organizational level has grown accordingly. Historically, software developed, or selected, for use
-in different projects and programmes has largely been managed on an ad-hoc basis. Independent experts, contractors,
-and implementing authorities / agencies have typically made independent choices without a common framework for the
-evaluation, governance, and life-cycle management of FOSS. Whilst enabling rapid development and innovation, this
-approach has led to fragmentation and duplication of effort, and in some cases, reliance on unmaintained or insecure
-software that puts Members services at risk.
+As FOSS has become increasingly embedded in WMO programmes, projects and Member operations, the need for structured coordination at the organizational level has grown accordingly. Historically, software developed, or selected, for use in different projects and programmes has largely been managed on an ad-hoc basis. Independent experts, contractors, and implementing authorities / agencies have typically made independent choices without a common framework for the evaluation, governance, and life-cycle management of FOSS.
 
-The WMO Secretariat, as the body supporting the work of its Members and constituent bodies, has a central role in coordinating
-FOSS activities across WMO programmes and projects and in supporting Members in the adoption of FOSS. This coordination
-function should ensure that FOSS initiatives adopted through WMO projects and programmes are aligned with the WMO's
-regulatory framework and that software used in support of WMO obligations meets appropriate standards of quality and
-security. Equally important, this coordination should ensure that Members, particularly those with more limited technical
-capacities, are not left behind.
+Whilst enabling rapid development and innovation, this approach has led to fragmentation and duplication of effort, and in some cases, reliance on unmaintained or insecure software that puts Members services at risk.
+
+The WMO Secretariat, as the body supporting the work of its Members and constituent bodies, has a central role in coordinating FOSS activities across WMO programmes and projects and in supporting Members in the adoption of FOSS. This coordination function should ensure that FOSS initiatives adopted through WMO projects and programmes are aligned with the WMO's regulatory framework and that software used in support of WMO obligations meets appropriate standards of quality and security. Equally important, this coordination should ensure that Members, particularly those with more limited technical capacities, are not left behind.
 
 ===== Governance and organizational functions
 
-Effective FOSS coordination with the WMO requires dedicated governance functions. The following functions are identified
-as essential:
+Effective FOSS coordination with the WMO requires dedicated governance functions. The following functions are identified as essential:
 
-* **Software evaluation and review**: Providing a consistent process for assessing FOSS used in WMO programmes and
-projects, applying criteria such as those described in the FOSS evaluation rubric (see <<annex-evaluation-rubric>>).
-This includes evaluating license compatibility, security posture, project and community health, openness of governance,
-and technical fitness for purpose.
-* **Lifecycle oversight**: Tracking the status of FOSS components used across WMO programmes, from initial adoption
-through operational use to end-of-life, ensuring that migration plans are in place when software is no longer maintained.
-* **Standards alignment**: Ensuring that FOSS developed or endorsed within WMO implements relevant Technical Regulations
-and open standards correctly and consistently.
+* **Software evaluation and review**: Providing a consistent process for assessing FOSS used in WMO programmes and projects, applying criteria such as those described in the FOSS evaluation rubric (see <<annex-evaluation-rubric>>).
+This includes evaluating license compatibility, security posture, project and community health, openness of governance, and technical fitness for purpose.
+* **Lifecycle oversight**: Tracking the status of FOSS components used across WMO programmes, from initial adoption through operational use to end-of-life, ensuring that migration plans are in place when software is no longer maintained.
+* **Standards alignment**: Ensuring that FOSS developed or endorsed within WMO implements relevant Technical Regulations and open standards correctly and consistently.
 * **Guidance and advisory support**: Providing practical guidance to Expert Teams, Task Teams, Communities of
-Practice, and other implementors on FOSS best practices, including licensing, contribution workflows, governance models
-and release management.
+Practice, and other implementors on FOSS best practices, including licensing, contribution workflows, governance models and release management.
 
-These functions may be carried out by existing WMO bodies, such as the Standing Committees, Expert Teams, and Task Teams.
-However, these bodies often have a narrow focus on a particular activity or area, are not typically involved in
-the projects implementing or using FOSS, and often lack the specialist knowledge on FOSS. Alternatively, a dedicated
-software review function, such as through an Open Source Program Office (OSPO), could be established. Regardless of the
-organizational form, there is a clear requirement for software governance to be systematic rather than ad-hoc, and that
-clear, objective criteria exist for evaluating and endorsing FOSS within WMO.
+These functions may be carried out by existing WMO bodies, such as the Standing Committees, Expert Teams, and Task Teams.  However, these bodies often have a narrow focus on a particular activity or area, are not typically involved in the projects implementing or using FOSS, and often lack the specialist knowledge on FOSS. Alternatively, a dedicated software review function, such as through an Open Source Program Office (OSPO), could be established. Regardless of the organizational form, there is a clear requirement for software governance to be systematic rather than ad-hoc, and that clear, objective criteria exist for evaluating and endorsing FOSS within WMO.
 
 It is important to note that WMO should not seek to develop its own registry of open-source software.
-Existing registries and ecosystems (such as those maintained by OSGeo, the Digital Public Goods Alliance, and
-language-specific package repositories) already serve this purpose.  WMO's coordination role should focus on evaluating
-and recommending software from within these existing ecosystems, rather than duplicating their efforts.
+
+Existing registries and ecosystems (such as those maintained by OSGeo, the Digital Public Goods Alliance, and language-specific package repositories) already serve this purpose.  WMO's coordination role should focus on evaluating and recommending software from within these existing ecosystems, rather than duplicating their efforts.
 
 ===== Roles and responsibilities
 
 Coordination of FOSS activities within the WMO involves a range of actors:
 
-* **WMO Secretariat**: Facilitates coordination across programmes and projects, supports the development and maintenance
-  of FOSS guidance, and manages relationships with external FOSS organizations.  The Secretariat also provides continuity
-  and institutional memory for FOSS initiatives that span multiple constituent body sessions.
-* **Expert Teams and Task Teams**: Provide domain-specific expertise in evaluating and developing FOSS relevant to their
-  areas of responsibility.  Expert Teams and Task Teams may identify candidate software for endorsement or develop Reference
-  Implementations of WMO standards.
-* **Communities of Practice**: Serve as collaborative spaces where Members, developers and stakeholders work together on
-  shared FOSS initiatives.  Communities of Practice can play an important role in maintaining and evolving software that
-  supports WMO standards, as demonstrated by the development of Reference Implementations within the WIS2 programme and
-  the OpenCDMS project and initiative.
-* **Members**: Contribute expertise, code, testing and operational feedback.  Members with mature FOSS programmes can
-  serve as mentors and collaborators for those building capacity.
+* **WMO Secretariat**: Facilitates coordination across programmes and projects, supports the development and maintenance of FOSS guidance, and manages relationships with external FOSS organizations.  The Secretariat also provides continuity and institutional memory for FOSS initiatives that span multiple constituent body sessions.
+* **Expert Teams and Task Teams**: Provide domain-specific expertise in evaluating and developing FOSS relevant to their areas of responsibility.  Expert Teams and Task Teams may identify candidate software for endorsement or develop <<_reference_implementations>> of WMO standards.
+* **Communities of Practice**: Serve as collaborative spaces where Members, developers and stakeholders work together on shared FOSS initiatives.  Communities of Practice can play an important role in maintaining and evolving software that supports WMO standards, as demonstrated by the development of <<_Reference Implementations within the WIS2 programme and the OpenCDMS project and initiative.
+* **Members**: Contribute expertise, code, testing and operational feedback.  Members with mature FOSS programmes can serve as mentors and collaborators for those building capacity.
 
-Whilst "Communities of Practice" have been listed above, these do not exist formally within the WMO's framework and
-constituent bodies, instead operating on an informal basis. Strengthening and formally recognising these communities
-would have significant benefit.
+Whilst "Communities of Practice" have been listed above, these do not exist formally within the WMO's framework and constituent bodies, instead operating on an informal basis. Strengthening and formally recognising these communities would have significant benefit.
 
 ===== FOSS project life cycle
 
 FOSS projects and software typically progress through several stages:
 
-* **Concept and prototyping**: An initial requirement is identified and ideas are explored. These may often be part
-of the development of a new standard, such as the WIS2.0 standards, or in response to an operational need. At this stage,
-the software may be experimental and maintained by a small number of developers.
-* **Development and pilot use**: Following initial prototyping, the software gains maturity and may have additional
-contributors. The software is tested in pilot environments. Parallel to this, the standards that the software is
-implementing may also gain maturity and undergo further changes.
-* **Operational use**: Software, and standards, are ready for production use in operational environments. There will be
-established governance processes for the FOSS together with comprehensive documentation and contribution guides. The
-contributor base will have grown and be sustainable.
-* **End-of-life and migration**: When software is no longer actively maintained or has been superseded, clear guidance
-should exist for migrating to alternative solutions, including data migration.  End-of-life planning is particularly
-important for software that Members depend on for operational services.
+* **Concept and prototyping**: An initial requirement is identified and ideas are explored. These may often be part of the development of a new standard, such as the WIS2.0 standards, or in response to an operational need. At this stage, the software may be experimental and maintained by a small number of developers.
+* **Development and pilot use**: Following initial prototyping, the software gains maturity and may have additional contributors. The software is tested in pilot environments. Parallel to this, the standards that the software is implementing may also gain maturity and undergo further changes.
+* **Operational use**: Software, and standards, are ready for production use in operational environments. There will be established governance processes for the FOSS together with comprehensive documentation and contribution guides. The contributor base will have grown and be sustainable.
+* **End-of-life and migration**: When software is no longer actively maintained or has been superseded, clear guidance should exist for migrating to alternative solutions, including data migration.  End-of-life planning is particularly important for software that Members depend on for operational services.
 
-The WMO can support this lifecycle by providing evaluation criteria at each stage, recognizing software that meets
-established thresholds of maturity, and facilitating transitions when software reaches end-of-life.  Established
-frameworks such as the OSGeo incubator and graduation processfootnote:[https://www.osgeo.org/resources/project-graduation-checklist/]
-provide a useful model for structuring such a lifecycle within the WMO.
+The WMO can support this lifecycle by providing evaluation criteria at each stage, recognizing software that meets established thresholds of maturity, and facilitating transitions when software reaches end-of-life.  Established frameworks such as the OSGeo incubator and graduation processfootnote:[https://www.osgeo.org/resources/project-graduation-checklist/] provide a useful model for structuring such a lifecycle within the WMO.
 
 ===== FOSS sustainability and risk management
 
-Sustainability, and long-term maintenance and support, are amongst the most significant challenges in FOSS adoption.
-Software that is relied upon by Members, especially for operational services, must be maintained over the long-term,
-with timely security updates and patches, compatibility updates and responsive support. Key risks to be managed include:
+Sustainability, and long-term maintenance and support, are amongst the most significant challenges in FOSS adoption.  Software that is relied upon by Members, especially for operational services, must be maintained over the long-term, with timely security updates and patches, compatibility updates and responsive support. Key risks to be managed include:
 
-* **Bus / retirement factor**: Over-reliance on a single, or small team, for critical software. When supporting FOSS
-  development and adoption, the WMO should encourage a broad contributor base, shared governance, and pooling of resources
-  for the support and development of critical software.
-* **Security vulnerabilities**: Software components must be subject to regular security reviews, with clear disclosure
-  and patching policies. Adequate resources must be in place to ensure any identified vulnerabilities are addressed in
-  a timely fashion.
-* **Dependency risk**: Software often depends on a chain of upstream libraries and components.  Understanding and
-  monitoring these dependencies is essential for assessing overall project health. This includes changes to upstream
-  licensing conditions.
-* **Funding and institutional support**: Whilst FOSS may be free of licensing costs there are still costs associated with
-  the development, maintenance, and operation of FOSS software. These costs are often hidden or neglected but should be
-  taken into account.
+* **Bus / retirement factor**: Over-reliance on a single, or small team, for critical software. When supporting FOSS development and adoption, the WMO should encourage a broad contributor base, shared governance, and pooling of resources for the support and development of critical software.
+* **Security vulnerabilities**: Software components must be subject to regular security reviews, with clear disclosure and patching policies. Adequate resources must be in place to ensure any identified vulnerabilities are addressed in a timely fashion.
+* **Dependency risk**: Software often depends on a chain of upstream libraries and components.  Understanding and monitoring these dependencies is essential for assessing overall project health. This includes changes to upstream licensing conditions.
+* **Funding and institutional support**: Whilst FOSS may be free of licensing costs there are still costs associated with the development, maintenance, and operation of FOSS software. These costs are often hidden or neglected but should be taken into account.
 
+The WMO has a role in supporting FOSS initiatives and managing risks by promoting and supporting investment in the development and maintenance of FOSS software and in community management. This support may be realised through sources such as the WMO Voluntary Cooperation Programme (VCP), extra-budgetary resources and projects, and through broader stakeholder and donor engagement.
 
-The WMO has a role in supporting FOSS initiatives and managing risks by promoting and supporting investment in the
-development and maintenance of FOSS software and in community management. This support may be realised through
-sources such as the WMO Voluntary Cooperation Programme (VCP), extra-budgetary resources and projects, and through
-broader stakeholder and donor engagement.
-
-The WMO's coordination role should include monitoring the health of FOSS that is critical to WMO programmes and alerting
-Members to emerging risks, such as previously promoted projects that show declining activity, unpatched vulnerabilities
-or loss of key maintainers.
+The WMO's coordination role should include monitoring the health of FOSS that is critical to WMO programmes and alerting Members to emerging risks, such as previously promoted projects that show declining activity, unpatched vulnerabilities or loss of key maintainers.
 
 ===== Alignment with the WMO ecosystem
 
-In the WMO context, FOSS initiatives should be aligned with the broader set of WMO activities in supporting Members.
-This includes:
+In the WMO context, FOSS initiatives should be aligned with the broader set of WMO activities in supporting Members.  This includes:
 
-* **Technical Regulations and standards**: Co-development of reference implementations alongside the development and
-  implementation of new regulations and standards; FOSS developed or endorsed should conform with and / or implement
-  WMO standards. The WMO should also promote alignment and interoperability with open standards, such as those developed by
-  the Open Geospatial Consortium.
-* **Cross-programme and cross-project coordination**: FOSS components are often relevant to multiple WMO programmes.
-  Coordination can help avoid duplication, identify opportunities for shared development and ensure that Members benefit
-  from a coherent set of tools rather than competing or overlapping solutions.
+* **Technical Regulations and standards**: Co-development of Reference Implementations alongside the development and implementation of new regulations and standards; FOSS developed or endorsed should conform with and / or implement WMO standards. The WMO should also promote alignment and interoperability with open standards, such as those developed by the Open Geospatial Consortium (OGC).
+* **Cross-programme and cross-project coordination**: FOSS components are often relevant to multiple WMO programmes.  Coordination can help avoid duplication, identify opportunities for shared development and ensure that Members benefit from a coherent set of tools rather than competing or overlapping solutions.
 
 ===== Supporting Members
 
-A key function of WMO coordination is ensuring that all Members can benefit from FOSS, regardless of their technical
-capacity, and making sure that no Member is left behind.  This includes:
+A key function of WMO coordination is ensuring that all Members can benefit from FOSS, regardless of their technical capacity, and making sure that no Member is left behind.  This includes:
 
-* **Capacity building**: Providing training, documentation and technical support to help Members evaluate, deploy and
-  maintain FOSS solutions.  This is particularly important for developing countries and small island developing states,
-  where resource constraints may limit the ability to engage with FOSS communities directly.
-* **Knowledge transfer**: Facilitating the exchange of experience and expertise between Members, for example through
-  workshops, code sprints and hackathons organized alongside WMO events or in collaboration with partner organizations.
-* **Visibility and discovery**: Helping Members identify FOSS that is relevant to their needs by curating
-  recommendations and maintaining awareness of available tools within the WMO community, drawing on existing registries
-  and partner ecosystems.
+* **Capacity building**: Providing training, documentation and technical support to help Members evaluate, deploy and maintain FOSS solutions.  This is particularly important for developing countries and small island developing states, where resource constraints may limit the ability to engage with FOSS communities directly.
+* **Knowledge transfer**: Facilitating the exchange of experience and expertise between Members, for example through workshops, code sprints and hackathons organized alongside WMO events or in collaboration with partner organizations.
+* **Visibility and discovery**: Helping Members identify FOSS that is relevant to their needs by curating recommendations and maintaining awareness of available tools within the WMO community, drawing on existing registries and partner ecosystems.
 
 ===== External partnerships
 
-The WMO does not operate in isolation in the FOSS landscape.  Established organizations such as the Open Source
-Geospatial Foundation (OSGeo), the Digital Public Goods Alliance (DPGA), the Apache Software Foundation and others have
-developed mature frameworks for FOSS governance, incubation and community management.  WMO should seek to leverage these
-existing frameworks rather than developing parallel structures.
+The WMO does not operate in isolation in the FOSS landscape.  Established organizations such as the https://osgeo.org[Open Source Geospatial Foundation (OSGeo)], the https://www.digitalpublicgoods.net[Digital Public Goods Alliance (DPGA)], the https://www.apache.org[Apache Software Foundation] and others have developed mature frameworks for FOSS governance, incubation and community management.  WMO should seek to leverage these existing frameworks rather than developing parallel structures.
 
 Potential areas for collaboration include:
 
-* **Formal partnerships:** Memoranda of Understanding (MoUs) with organizations such as OSGeo can provide a structured
-  basis for collaboration on project governance, incubation and quality assurance.
-* **Registration as Digital Public Goods:** Key WMO FOSS implementations may qualify for registration with the DPGA,
-  increasing their visibility and credibility within the broader international development community.
-* **Joint events:** Code sprints, hackathons and workshops organized in collaboration with partner organizations (such
-  as OGC/OSGeo/ASF joint sprints or FOSS4G conferences) provide valuable opportunities for capacity building, community
-  engagement and collaborative development.
-* **Regional digital innovation hubs**: Regional digital innovation hubs, established in collaboration with Members,
-  national and international development agencies, and regional organizations, can play an important role in the
-  development and implementation of FOSS solutions, with a focus on meeting the needs of Members within a region. These
-  could be co-located, or hosted, by existing regional centres.
+* **Formal partnerships:** Memoranda of Understanding (MoUs) with organizations such as OSGeo can provide a structured basis for collaboration on project governance, incubation and quality assurance.
+* **Registration as Digital Public Goods:** Key WMO FOSS implementations may qualify for registration with the DPGA, increasing their visibility and credibility within the broader international development community.
+* **Joint events:** Code sprints, hackathons and workshops organized in collaboration with partner organizations (such as OGC/OSGeo/ASF joint sprints or https://foss4g.org[FOSS4G conferences]) provide valuable opportunities for capacity building, community engagement and collaborative development.
+* **Regional digital innovation hubs**: Regional digital innovation hubs, established in collaboration with Members, national and international development agencies, and regional organizations, can play an important role in the development and implementation of FOSS solutions, with a focus on meeting the needs of Members within a region. These could be co-located, or hosted, by existing regional centres.
 
 
 
@@ -208,12 +128,17 @@ To support early-stage identification and comparison, Members and WMO activities
 
 For consistency and transparency, WMO encourages the use of a common evaluation checklist or rubric, such as the one provided in <<annex-evaluation-rubric, Annex A>>, and promotes rolling reviews of selected software to account for evolving requirements, standards and ecosystem changes. This assessment process does not seek to formally “approve” specific software for inclusion in WMO Technical Regulations, but rather to provide confidence-based guidance and shared criteria to support informed decision-making and harmonized adoption across the WMO ecosystem. 
 
-* "Approved projects" and/or Reference Implementations
-** Make Tech Regs more concrete
-** Tech Regs -> FOSS implementations
-** Should FOSS be cited in WMO Tech Regs (suggest no)
-** Rolling review
-* Harmonization: regular review of ecosystem to ensure alignment and optimal use of resources
+==== Reference Implementations
+
+Reference Implementations (RIs) are key resources for the precise implementation of a given standard or requirement set.  Benefits of RIs include (but are not limited to):
+
+* validating the functionality and capability of a given standard (for example, for data encodings or interfaces)
+* providing a publicly available FOSS resource that is definitive and can be studied to better understand and/or implement a standard
+* providing an implementation that may be used by Members as desired
+
+RIs developed alongside a given specification are especially useful for agile, rapid and iterative feedback during the specification definition phase, leading to the approval of Technical Regulations with confidence.  It is therefore strongly recommended to develop RIs as part of WMO Technical Regulation development to ensure fit for purpose and functionality.  Citing a RI as part of a WMO Technical Regulation should not be required, but allowed if applicable.
+
+NOTE: They key purpose of an RI is functionality coverage.  They need not be suitable for mission critical or production environments.
 
 ===== Compliance (data exchange)
 
@@ -309,4 +234,4 @@ Throughout the WIS2 Implementation timeline, the https://raw.githubusercontent.c
 
 Driven by collaboration, the development and testing of FOSS significantly helped with early assessment of the WIS2 standards in development.  As a result, WIS2 standards were being tested in an agile environment and rapid feedback was provided that helped refine, adjust and improve the standards early and often.
 
-WIS2 FOSS implementations have resulted in a more stable and robust program delivery with significantly reduced risk to Members.  In addition, some tools have emerged as "Reference Implementations" as key resources for the precise implementation of various WIS2 standards which can either be deployed or studied by Members accordingly.  WIS2 Technical Regulations were approved with confidence as a result of the agile development of Open Standards and Open Source.
+WIS2 FOSS implementations have resulted in a more stable and robust program delivery with significantly reduced risk to Members.  In addition, some tools have emerged as <<_reference_implementations>>.  WIS2 Technical Regulations were approved with confidence as a result of the agile development of Open Standards and Open Source.

--- a/guide/sections/guidelines/wmo-members.adoc
+++ b/guide/sections/guidelines/wmo-members.adoc
@@ -76,7 +76,7 @@ and ecosystem flexibility—offering both practical advantages and adaptability.
 
 ==== Profiling competencies
 
-Members wishing to use, participate and/or manage FOSS activities should be familiar with basic FOSS principles, and assess their level of participation accordingly.  Understanding the architecture of participation of FOSS varies among projects.  In addition to domain and software development competencies, staff require the ability to analyze a given FOSS project and/or community, understanding how development, contributions and social and political infrastructure operate.  Staff should also be supported to participate in FOSS as part of their ongoing learning and development.  The degree to which these skills are developed depend on the level of FOSS investment by a given Member organization.
+Members wishing to use, participate and/or manage FOSS activities should be familiar with basic FOSS principles, and assess their level of participation accordingly.  Understanding the architecture of participation of FOSS varies among projects.  In addition to domain and software development competencies, staff require the ability to analyze a given FOSS project and/or community, understanding how development, contributions and social and political infrastructure operate.  Staff should also be supported to participate in FOSS as part of their ongoing learning and development.  This can include attending conferences and/or code sprints and hackathons.  The degree to which these skills are developed depend on the level of FOSS investment by a given Member organization.
 
 ==== Infrastructure considerations
 

--- a/guide/sections/guidelines/wmo-members.adoc
+++ b/guide/sections/guidelines/wmo-members.adoc
@@ -2,45 +2,19 @@
 
 ==== Using FOSS
 
-* FOSS as an option during software evaluation
-* Risk, hidden costs (TODO Jian)
-** Principles apply to ANY software
-** Risk management
-** Due diligence (maintenance, updates)
-* Lifecycle management/EOL -> migration
-* Total cost of ownership considerations
-** HR profile / IT capacity of organization
-* Benefits (freedom, cost, reducing vendor lock in, portability) (TODO Jian)
-* Infrastructure considerations
-
 ===== Risks
 
-* **License compliance risks** Open source licenses often have widely varying requirements regarding commercial use,
-redistribution, and code modification. Certain licenses include restrictive clauses, such as mandating that derivative
-works be made open source or that original copyright notices be preserved in full. Violations may lead to legal disputes
-and intellectual property issues.
-* **Security and continuity risks**: Open source software from niche projects or less-established projects may pose
-security risks due to limited formal code audits. Additionally, the complexity of open source software supply chains
-creates vulnerabilities that could be exploited to implant malicious code. These risks are amplified in meteorological
-applications, especially  when handling sensitive observational data or real-time forecasting models.
-* **Maintenance risks**: Fixes for vulnerabilities rely on community responsiveness. If an open source project is
-discontinued,  known vulnerabilities may remain unaddressed.
-* **Support risks**: Most open source software lacks official support. As a result, timely response and effective
-resolutions of critical operational system failures cannot be guaranteed, potentially leading to interruptions
-in meteorological operation and data loss.
+* **License compliance risks** Open source licenses often have widely varying requirements regarding commercial use, redistribution, and code modification. Certain licenses include restrictive clauses, such as mandating that derivative works be made open source or that original copyright notices be preserved in full. Violations may lead to legal disputes and intellectual property issues.
+* **Security and continuity risks**: Open source software from niche projects or less-established projects may pose security risks due to limited formal code audits. Additionally, the complexity of open source software supply chains creates vulnerabilities that could be exploited to implant malicious code. These risks are amplified in meteorological applications, especially  when handling sensitive observational data or real-time forecasting models.
+* **Maintenance risks**: Fixes for vulnerabilities rely on community responsiveness. If an open source project is discontinued,  known vulnerabilities may remain unaddressed.
+* **Support risks**: Most open source software lacks official support. As a result, timely response and effective resolutions of critical operational system failures cannot be guaranteed, potentially leading to interruptions in meteorological operation and data loss.
 
 ===== Hidden costs
 
-* **Technical adaptation and integration costs**: Human resources must be allocated for secondary development (customization),
-system interface integration, and compatibility testing to ensure the software aligns with existing business systems.
-* **Long-term maintenance and version management costs**: Dedicated personnel are needed to track version updates, conduct
-testing, and manage migrations. If a project is discontinued, taking over its maintenance internally entails high
-technical challenges and added operational complexity.
-* **Talent acquisition and training costs**: Recruiting skilled professionals can be expensive, and ongoing in-house
-training is required to maintain the necessary expertise.
-* **Compliance audit and management costs**: It is necessary to maintain an inventory of all open source components and
-perform regular compliance audits. Large meteorological organizations may also need to develop dedicated management
-platforms, with costs increasing as the number of components grows.
+* **Technical adaptation and integration costs**: Human resources must be allocated for secondary development (customization), system interface integration, and compatibility testing to ensure the software aligns with existing business systems.
+* **Long-term maintenance and version management costs**: Dedicated personnel are needed to track version updates, conduct testing, and manage migrations. If a project is discontinued, taking over its maintenance internally entails high technical challenges and added operational complexity.
+* **Talent acquisition and training costs**: Recruiting skilled professionals can be expensive, and ongoing in-house training is required to maintain the necessary expertise.
+* **Compliance audit and management costs**: It is necessary to maintain an inventory of all open source components and perform regular compliance audits. Large meteorological organizations may also need to develop dedicated management platforms, with costs increasing as the number of components grows.
 
 
 ==== Contributing to FOSS
@@ -95,25 +69,14 @@ In the same spirit as contributing to FOSS, where no national regulations exist,
 The core benefits of open source software can be summarized on three dimensions: autonomy and control, cost optimization,
 and ecosystem flexibility—offering both practical advantages and adaptability. Details are as follows:
 
-* **Exceptional autonomy and control**: The code is open and licenses are flexible, allowing meteorological organizations
-to perform deep customization as needed, directly modifying the code to add or remove functional modules to suit unique
-operational scenarios (e.g., regional weather forecasting adjustments). This level of access also allows them to
-independently identify and fix vulnerabilities, optimize performance for massive meteorological data processing, and
-control the technical roadmap of core systems. Certain permissive licenses (e.g., MIT License, Apache License 2.0) even
-permit using modified code as closed source in commercial products, balancing customization needs with operational requirements.
-* **Significant cost advantages**: No software license fees or subscription fees are required, suitable for national meteorological
-services as well as deployments in regional forecasting centers. The availability of source code and community documentation
-reduces trial-and-error costs during secondary development, making necessary human resource investment more manageable.
-Meteorological organizations can also choose free community support or affordable third-party services (specialized in
-meteorological applications) instead of expensive vendor support packages.
-* **Avoiding vendor lock-in risks**: Free from proprietary interfaces and data format dependencies, enabling free choice of
-deployment environments (e.g., private or public clouds). Even if the original project is discontinued, maintenance can
-be taken over independently or by a third party. Moreover, multiple service providers are often support the same open
-source software, strengthening the user’s bargaining power.
-* **Excellent cross-platform portability**: Most open source tools run on multiple operating systems (e.g., Windows and
-Linux), eliminating the need for separate purchases. Adherence to common technical standards (e.g., WMO GRIB data formats)
-lowers system integration difficulty. Modular design facilitates containerized deployment and cross-cluster migration,
-adapting to architectural upgrades in meteorological data centers.
+* **Exceptional autonomy and control**: The code is open and licenses are flexible, allowing meteorological organizations to perform deep customization as needed, directly modifying the code to add or remove functional modules to suit unique operational scenarios (e.g., regional weather forecasting adjustments). This level of access also allows them to independently identify and fix vulnerabilities, optimize performance for massive meteorological data processing, and control the technical roadmap of core systems. Certain permissive licenses (e.g., MIT License, Apache License 2.0) even permit using modified code as closed source in commercial products, balancing customization needs with operational requirements.
+* **Significant cost advantages**: No software license fees or subscription fees are required, suitable for national meteorological services as well as deployments in regional forecasting centers. The availability of source code and community documentation reduces trial-and-error costs during secondary development, making necessary human resource investment more manageable.  Meteorological organizations can also choose free community support or affordable third-party services (specialized in meteorological applications) instead of expensive vendor support packages.
+* **Avoiding vendor lock-in risks**: Free from proprietary interfaces and data format dependencies, enabling free choice of deployment environments (e.g., private or public clouds). Even if the original project is discontinued, maintenance can be taken over independently or by a third party. Moreover, multiple service providers are often support the same open source software, strengthening the user’s bargaining power.
+* **Excellent cross-platform portability**: Most open source tools run on multiple operating systems (e.g., Windows and Linux), eliminating the need for separate purchases. Adherence to common technical standards (e.g., WMO GRIB data formats) lowers system integration difficulty. Modular design facilitates containerized deployment and cross-cluster migration, adapting to architectural upgrades in meteorological data centers.
+
+==== Profiling competencies
+
+Members wishing to use, participate and/or manage FOSS activities should be familiar with basic FOSS principles, and assess their level of participation accordingly.  Understanding the architecture of participation of FOSS varies among projects.  In addition to domain and software development competencies, staff require the ability to analyze a given FOSS project and/or community, understanding how development, contributions and social and political infrastructure operate.  Staff should also be supported to participate in FOSS as part of their ongoing learning and development.  The degree to which these skills are developed depend on the level of FOSS investment by a given Member organization.
 
 ==== Infrastructure considerations
 

--- a/guide/sections/references.adoc
+++ b/guide/sections/references.adoc
@@ -1,2 +1,3 @@
 == References
 
+* [[producing-oss]] Fogel, Karl: Producing Open Source Software: How to Run a Successful Free Software Project (2024) footnote:[https://producingoss.com]


### PR DESCRIPTION
This PR provides updates on Reference Implementations as well as skills and competencies.  In addition, it removes some leftover TODOs that have been already addressed.  Finally, some formatting fixes are applied to various paragraphs.

A PDF for reviewing in context is [attached](https://github.com/user-attachments/files/25431520/wmo-foss-guide-DRAFT.pdf).
