### PR TITLE
Add US data policy documents to the Data Policies annex.

### DIFF
--- a/guide/sections/annex-data-policies.adoc
+++ b/guide/sections/annex-data-policies.adoc
@@ -26,3 +26,9 @@
 ** https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/information-management.html
 * United Kingdom
 ** https://www.gov.uk/guidance/national-data-strategy
+* United States
+** National Oceanic and Atmospheric Administration (NOAA)
+*** https://www.noaa.gov/organization/administration/nao-212-15-Management-of-NOAA-Data-and-Information
+*** https://sciencecouncil.noaa.gov/wp-content/uploads/2022/08/2020-Data-Strategy.pdf
+** National Aeronautics and Space Administration (NASA)
+*** https://www.nasa.gov/wp-content/uploads/2025/07/nasa-data-strategy.pdf


### PR DESCRIPTION
I added links for all three documents I mentioned in the issue (fixes #28) and spelled out agency names. Happy to update to only list URLs as elsewhere or to only list one URL (the first one) as is done for all the other national listings. (The second and third documents are data strategy rather than policy. So maybe shouldn't be listed anyway.) Any preferences - @tomkralidis @david-i-berry all?