### PR TITLE
update per TT-OSS 2026-06-23 discussion/feedback

### DIFF
--- a/guide/sections/guidelines/wmo-members.adoc
+++ b/guide/sections/guidelines/wmo-members.adoc
@@ -18,7 +18,9 @@ The benefits of FOSS are well evidenced, though they vary significantly by conte
 
 ===== Risks
 
-The use of FOSS may introduce a range of risks that should be carefully assessed and managed, particularly in operational environments where reliability, security, and compliance are critical. It is worth noting that many of these risks apply equally to commercially licensed software.
+NOTE: it should be made clear that using, contributing to, or managing **any software** (FOSS, proprietary, etc.) requires a risk analysis and mitigation as part of planning an implementation or project/activity.
+
+The use of FOSS may introduce a range of risks that should be carefully assessed and managed, particularly in operational environments where reliability, security, and compliance are critical.
 
 * **Licence compliance risks — users**: Members using FOSS internally, without modification or redistribution to third parties, face minimal licence compliance risk in most cases. The principal exception is the Affero GPL (AGPL), which extends copyleft obligations to software used to provide network services even without distribution; NMHSs operating web-based or API services should assess AGPL-licensed components carefully.
 * **Licence compliance risks — contributors and distributors**: Members who modify FOSS and distribute it to third parties face broader obligations. Copyleft licences (for example, GPL, LGPL) require that derivative works be made available under the same terms and that original copyright notices be preserved. Where FOSS components with different licences are combined, compatibility between those licences must also be assessed. Violations of applicable licence terms may lead to legal disputes and intellectual property issues.
@@ -27,15 +29,17 @@ The use of FOSS may introduce a range of risks that should be carefully assessed
 * **Dependency and stack maintenance risks**: FOSS solutions typically depend on a broader ecosystem of libraries, frameworks, and runtime components. Keeping the full software stack up to date, including across upstream dependencies, requires continuous effort. Version incompatibilities, breaking changes upstream, and end-of-life releases can create significant operational burden, particularly for small teams managing operational meteorological systems.
 * **Support risks**: Most open-source software lacks official support. As a result, timely response and effective resolution of critical operational system failures cannot be guaranteed, potentially leading to interruptions in meteorological operations and data loss.
 
-===== Cost Implications
+===== Cost implications
 
-The use of FOSS may entail cost implications that should be carefully assessed, particularly with regard to integration, maintenance, and long-term resource requirements. As with risks, many of these considerations apply equally to commercially licensed software.
+NOTE: it should be made clear that using, contributing to, or managing **any software** (FOSS, proprietary, etc.) entails cost.
+
+The cost of using FOSS should be carefully assessed, particularly with regard to integration, maintenance, and long-term resource requirements.
 
 * **Technical adaptation and integration costs**: Human resources must be allocated for software customization and adaptation, system interface integration, and compatibility testing to ensure the software aligns with existing systems.
 * **Long-term maintenance and version management costs**: Dedicated personnel are needed to track version updates, conduct testing, and manage migrations. If a project is discontinued, taking over its maintenance internally entails high technical challenges and added operational complexity.
 * **Talent acquisition and training costs**: Recruiting skilled professionals can be expensive, and ongoing in-house training is required to maintain the necessary expertise.
 * **Compliance audit and management costs**: It is necessary to maintain an inventory of all open-source components and perform regular compliance audits. Large meteorological organizations may also need to develop dedicated management platforms, with costs increasing as the number of components grows.
-* **Proprietary software pricing risks**: When assessing the cost implications of FOSS, these should be considered alongside the risks of commercially licensed alternatives, which may include vendor-driven migration to subscription-only licensing models (whether cloud-based or locally deployed software requiring ongoing licence validation), significant price increases, and ratchet mechanisms that progressively erode an organization's bargaining position and ability to exit the relationship.
+* **Proprietary software pricing risks**: When assessing the cost implications of FOSS, these should be considered alongside the risks of proprietary alternatives, which may include vendor-driven migration to subscription-only licensing models (whether cloud-based or locally deployed software requiring ongoing licence validation), significant price increases, and ratchet mechanisms that progressively erode an organization's bargaining position and ability to exit the relationship.
 
 The risks and costs described above are faced by individual Members when adopting FOSS. The broader systemic implications — including WMO's role in monitoring project health, managing community-wide sustainability risks, and supporting Members when critical software reaches end-of-life — are addressed in <<_foss_sustainability_and_risk_management>>.
 
@@ -61,6 +65,14 @@ Where no national regulations exist, NMHSs can still develop institution-level p
 * Promote transparency by adopting open repositories for research software and operational tools. 
 
 Participation in events such as code sprints, hackathons and conferences (for example,OGC/OSGeo/ASF joint sprints and FOSS4G) provides valuable opportunities for capacity building, community engagement and collaborative development. OSGeo also supports a network of local chaptersfootnote:[https://wiki.osgeo.org/wiki/Local_Chapters] that can serve as regional points of contact for FOSS engagement. WMO's coordination role in facilitating such events and managing partnerships with external FOSS organizations is described in <<_external_partnerships>>.
+
+Different formats serve different purposes:
+
+* **Conferences* (for example, the https://foss4g.org[FOSS4G] series and its regional editions) combine presentations, workshops and networking, and are a good entry point for staff new to a community
+* **Code sprints* bring contributors together, in person or remotely, to work intensively on a shared codebase. The joint OGC/OSGeo/ASF code sprints are a long-running example that pairs standards development with FOSS implementation, allowing specification editors and developers to work side by side
+* **Hackathons* focus on rapid prototyping around a defined challenge, and are well suited to exploring new ideas and onboarding newcomers, while documentation and bug-squashing sprints offer an accessible route to a first contribution
+
+Members can engage beyond simply attending by sending staff as contributors rather than observers, hosting or sponsoring regional editions co-located with WMO meetings and proposing challenges or datasets that reflect operational needs. OSGeo supports a network of local chapters footnote:[https://wiki.osgeo.org/wiki/Local_Chapters] that can serve as regional points of contact for organizing or joining such events.
 
 ==== Managing FOSS activities
 

--- a/guide/sections/introduction.adoc
+++ b/guide/sections/introduction.adoc
@@ -15,9 +15,7 @@ The document is intended for WMO Members who are involved in software acquisitio
 
 === Scope
 
-This document provides guidance on FOSS for WMO Members and WMO Secretariat, both in terms of using FOSS but also
-in the development and contribution to FOSS projects. The guidance is equally applicable to internally developed
-software, and to commercially sourced or supported software.
+This document provides guidance on FOSS for WMO Members and WMO Secretariat, both in terms of using FOSS but also in the development and contribution to FOSS projects. The guidance is equally applicable to any software (FOSS, proprietary, etc.).
 
 === Background
 


### PR DESCRIPTION
Per [TT-OSS 2026-06-23](https://github.com/wmo-im/tt-oss/wiki/Meeting-2026-06-23)
  - [x] Open a PR to clarify risk/cost implications wording (change "commercially licensed software" to "all software", and sweep other instances of "commercially licensed" in the document)
  - [x] Remove "may" from the opening sentence of the cost implications section
  - [x] Incorporate Vasile's hackathon/joint sprint section text